### PR TITLE
feat(block-sdk) x/auction rename + fixes

### DIFF
--- a/docs/0-searcher-docs.md
+++ b/docs/0-searcher-docs.md
@@ -24,7 +24,7 @@ Searchers submit bundles by broadcasting a `AuctionTx` in the same way they broa
 #### Default Auction Bid Message
 
 ```go
-// MsgAuctionBid defines a request type for sending bids to the x/builder
+// MsgAuctionBid defines a request type for sending bids to the x/auction
 // module.
 type MsgAuctionBid struct {
     // bidder is the address of the account that is submitting a bid to the
@@ -143,7 +143,7 @@ func createBidTx(
 ### ⚙️ Auction fees
 
 :::info Auction Configuration
-All auction parameters are accessible though the `/block-sdk/x/builder/v1/params` HTTP path on a standard node or gRPC service defined by `x/builder`.
+All auction parameters are accessible though the `/block-sdk/x/auction/v1/params` HTTP path on a standard node or gRPC service defined by `x/auction`.
 :::
 
 In order to participate in an auction, searchers must pay a fee. This fee is paid in the native token of the chain. The fee is determined by the auction parameters, which are set by the chain. The auction parameters are:
@@ -171,7 +171,7 @@ Bundle Examples:
 #### Querying auction parameters
 
 ```go
-func getAuctionParams() (*buildertypes.Params, error) {
+func getAuctionParams() (*auctiontypes.Params, error) {
     # Replace this URL with the gRPC url of a node
     url := "localhost:9090"
 
@@ -184,11 +184,29 @@ func getAuctionParams() (*buildertypes.Params, error) {
         return nil, err
     }
 
-    client := buildertypes.NewQueryClient(grpcConn)
+    client := auctiontypes.NewQueryClient(grpcConn)
 
-    req := &buildertypes.QueryParamsRequest{}
+    req := &auctiontypes.QueryParamsRequest{}
     resp, err := client.Params(context.Background(), req)
 
     return resp.Params
 }
 ```
+
+### 🚨 Chains currently using the MEV-Lane
+
+#### Mainnets
+
+| Chain Name  | Chain-ID        | Block-SDK Version |
+| ----------- | --------------- | ----------------- |
+| Juno        | `juno-1`        | `v1.0.2`          |
+| Persistence | `persistence-1` | `v1.0.2`          |
+| Initia      | `NA`            | `v1.0.2`          |
+| Prism       | `NA`            | `v1.0.2`          |
+| Terra       | `phoenix-1`     | `v1.0.2`          |
+
+#### Testnets
+
+| Chain Name | Chain-ID | Block-SDK Version |
+| ---------- | -------- | ----------------- |
+| Juno       | `uni-6`  | `v1.0.2`          |

--- a/docs/chains/0-integrate-the-sdk.md
+++ b/docs/chains/0-integrate-the-sdk.md
@@ -14,7 +14,69 @@ Please [**reach out to us**](https://skip.money/contact) if you need help!
 
 :::
 
-### 📖 Set Up [20 mins]
+## ⚙️ Architecture [15 mins]
+
+:::note
+This is a high-level overview of the architecture, please reference [this page](/docs/chains/2-how-it-works.md) or the [`Block-SDK` repo](https://github.com/skip-mev/block-sdk) for detailed and up to date info. For those eager to code, feel free to skip this and start down the page at **Set Up**!
+:::
+
+### How Were Blocks Constructed pre-Block-SDK?
+
+There are 3 relevant stages of consensus (these are all ABCI++ methods)
+
+- **PrepareProposal**
+  - In this step, the consensus-engine (CometBFT, etc.) gives the application all of the transactions it has seen thus far.
+  - The app looks over these, performs some app-specific logic, and then gives them back to the consensus-engine. The consensus-engine then creates and broadcasts a proposal containing the transactions sent back from the app.
+- **ProcessProposal**
+  - In this step, all validators check that the transactions in the proposal are valid, and that the proposal (as a whole) satisfies validity conditions determined by the application
+    - If the proposal fails, validators will not vote on the block, and the network will be forced to another round of consensus
+    - if the proposal passes, valdiators vote on the block, and the block will become canonical (barring unforeseen events)
+
+### **Application Mempools**
+
+In `v0.47.0` of the cosmos-sdk, **app-side mempools** were added to the SDK. With app-side mempools, validators no longer need to rely on the consensus-engine to keep track of and order all available transactions. Now applications can define their own mempool implementations, that
+
+1. Store all pending (not finalized in a block) transactions
+2. Order the set of pending transactions
+
+#### **How does block-building change?**
+
+Now in **PrepareProposal** instead of getting transactions from the consensus-engine, validators can pull transactions from their application-state aware mempools, and prioritize those transactions instead of the consensus-engine's transactions.
+
+**Why is this better?**
+
+- Mempools that are not app-state aware will not have the ability to make state-aware ordering rules. Like
+
+1. All staker transactions are placed at the top of the block
+2. All IBC `LightClientUpdate` messages are placed at the top of the block
+3. Anything you can think of!!
+
+- The consensus engine's mempool is generally in-efficient.
+  - The consensus-engine's mempool does not know when to remove transactions from its own mempool
+  - The consensus-engine spends most of its time re-broadcasting transactions between peers, hogging network bandwidth
+
+## Block-SDK!!
+
+The `Block-SDK` defines its own custom implementation of an **app-side mempool**, a `LaneMempool`. The `LaneMempool` is composed of `Lanes`, and handles transaction ingress, ordering, and cleaning.
+
+**transaction ingress**
+
+- The `LanedMempool` constructor defines an ordering of lanes. When a transaction is received by the app, it iterates through all lanes in order and inserts the transaction into the first `Lane` that it belongs in.
+  **ordering**
+- Each `Lane` of the `LanedMempool` maintains its own ordering of transactions. When the `LanedMempool` routes a transaction to its corresponding `Lane` the `Lane` then inserts the transaction at its designated position with respect to all other transactions in the lane
+
+### PrepareProposal
+
+When the application is instructed to `PrepareProposal` it iterates through its `Lane`s in order, and calls each `Lane`'s `PrepareLane` method. The `Lane.PrepareLane` method collects transactions from a `Lane` and appends those transactions to the set of transactions from previous `Lane`'s `PrepareLane` calls. In other words, each block-proposal is now a collection of the transactions from the `LanedMempool`'s constituent lanes.
+
+### ProcessProposal
+
+When the application receives a proposal, and calls `ProcessProposal`, the app delegates the validation to the `LaneMempool.ProcessLanes` method. Remember, the proposal is composed of transactions from the sub-lanes of the `LaneMempool`, as such, the `LaneMempool` can route each `Lane`'s contribution to the Proposal to that `Lane` for validation. The proposal passes iff all `Lane`'s contributions are valid.
+:::note ⚠️
+A block constructed from a `LaneMempool`'s `PrepareLanes` method must always pass that `LaneMempool`'s `ProcessLanes` method, otherwise, the chain will fail to produce blocks!! These functions are consensus critical, so practice caution when implementing them!!
+:::
+
+## 📖 Set Up [20 mins]
 
 To get set up, we're going to implement the `Default Lane`, which is the **most general and least restrictive** that accepts all transactions. This will cause **no changes** to your chain functionality, but will prepare you to add `lanes` with more functionality afterwards!
 
@@ -27,7 +89,129 @@ The default lane mirrors how CometBFT creates proposals today.
 
 <!-- TODO: create script -->
 
-{{ readme }}
+# 🏗️ Default Lane Setup
+
+## 📦 Dependencies
+
+The Block SDK is built on top of the Cosmos SDK. The Block SDK is currently
+compatible with Cosmos SDK versions greater than or equal to `v0.47.0`.
+
+### Release Compatibility Matrix
+
+| Block SDK Version | Cosmos SDK |
+| :---------------: | :--------: |
+|     `v1.x.x`      | `v0.47.x`  |
+|     `v2.x.x`      | `v0.50.x`  |
+
+## 📥 Installation
+
+To install the Block SDK, run the following command:
+
+```bash
+$ go install github.com/skip-mev/block-sdk
+```
+
+## 📚 Usage
+
+1. First determine the set of lanes that you want to use in your application. The
+   available lanes can be found in our
+   [Lane App Store](https://docs.skip.money/chains/lanes/existing-lanes/default). This guide only sets up the `default lane`
+
+```golang
+import (
+    "github.com/skip-mev/block-sdk/abci"
+    "github.com/skip-mev/block-sdk/block/base"
+    defaultlane "github.com/skip-mev/block-sdk/lanes/base"
+)
+
+    // 1. Create the lanes.
+    //
+    // NOTE: The lanes are ordered by priority. The first lane is the highest priority
+    // lane and the last lane is the lowest priority lane. Top of block lane allows
+    // transactions to bid for inclusion at the top of the next block.
+    //
+    // For more information on how to utilize the LaneConfig please
+    // visit the README in docs.skip.money/chains/lanes/build-your-own-lane#-lane-config.
+    //
+    // Default lane accepts all transactions.
+
+func NewApp() {
+    ...
+    defaultConfig := base.LaneConfig{
+        Logger:        app.Logger(),
+        TxEncoder:     app.txConfig.TxEncoder(),
+        TxDecoder:     app.txConfig.TxDecoder(),
+        MaxBlockSpace: math.LegacyZeroDec(),
+        MaxTxs:        0,
+    }
+    defaultLane := defaultlane.NewDefaultLane(defaultConfig)
+    // TODO(you): Add more Lanes!!!
+```
+
+2. In your base application, you will need to create a `LanedMempool` composed
+   of the `lanes` you want to use.
+
+```golang
+        // 2. Set up the relative priority of lanes
+        lanes := []block.Lane{
+            defaultLane,
+        }
+        mempool := block.NewLanedMempool(app.Logger(), true, lanes...)
+        app.App.SetMempool(mempool)
+```
+
+3. Next, order the lanes by priority. The first lane is the highest priority lane
+   and the last lane is the lowest priority lane. **It is recommended that the last
+   lane is the default lane.**
+
+```golang
+    // 3. Set up the ante handler.
+    anteDecorators := []sdk.AnteDecorator{
+		ante.NewSetUpContextDecorator(),
+        ...
+		utils.NewIgnoreDecorator(
+			ante.NewDeductFeeDecorator(
+				options.BaseOptions.AccountKeeper,
+				options.BaseOptions.BankKeeper,
+				options.BaseOptions.FeegrantKeeper,
+				options.BaseOptions.TxFeeChecker,
+			),
+			options.FreeLane,
+		),
+        ...
+	}
+
+    anteHandler := sdk.ChainAnteDecorators(anteDecorators...)
+
+    // Set the lane ante handlers on the lanes.
+    //
+    // NOTE: This step is very important. Without the antehandlers, lanes will not
+    // be able to verify transactions.
+    for _, lane := range lanes {
+        lane.SetAnteHandler(anteHandler)
+    }
+    app.App.SetAnteHandler(anteHandler)
+```
+
+4. You will also need to create a `PrepareProposalHandler` and a
+   `ProcessProposalHandler` that will be responsible for preparing and processing
+   proposals respectively. Configure the order of the lanes in the
+   `PrepareProposalHandler` and `ProcessProposalHandler` to match the order of the
+   lanes in the `LanedMempool`.
+
+```golang
+    // 4. Set the abci handlers on base app
+    // Create the LanedMempool's ProposalHandler
+    proposalHandler := abci.NewProposalHandler(
+        app.Logger(),
+        app.TxConfig().TxDecoder(),
+        mempool,
+    )
+
+    // set the Prepare / ProcessProposal Handlers on the app to be the `LanedMempool`'s
+    app.App.SetPrepareProposal(proposalHandler.PrepareProposalHandler())
+    app.App.SetProcessProposal(proposalHandler.ProcessProposalHandler())
+```
 
 ### 💅 Next step: implement other `lanes`
 

--- a/docs/chains/1-overview.md
+++ b/docs/chains/1-overview.md
@@ -12,12 +12,24 @@ The Block SDK is a set of Cosmos SDK and ABCI++ primitives that allow chains to 
 
 Skip has built out a number of plug-and-play `lanes` on the SDK that your protocol can use, including in-protocol MEV recapture and Oracles! Additionally, the Block SDK can be extended to add **your own custom `lanes`** to configure your blocks to exactly fit your application needs.
 
+:::note 🚦 **Blocks are like highways**
+Let's say you're the designer of a 4 lane highway. You'd want a paid lane, for fast drivers who'd like to be separated from other lanes. You'd like a lane for large vehicles, you can configure this lane to be wider, require more space between vehicles, etc. The other two lanes are for the rest of traffic. The beauty here, is that as the owner of the highway, you get to decide what vehicles (transactions) you'll allow, and how they can behave (ordering)!!
+:::
+
+#### If you've been here before
+
+##### [Integrate Block-SDK](/docs/chains/0-integrate-the-sdk.md)
+
+##### [Building your own Lane](/docs/chains/lanes/1-build-your-own-lane.md)
+
+##### [Searcher docs for MEV Lane](/docs/0-searcher-docs.md)
+
 ### ❌ Problems: Blocks are not Customizable
 
-Most Cosmos chains today utilize standard `CometBFT` block construction - which is too limited.
+Most Cosmos chains today utilize traditional block construction - which is too limited.
 
-- The standard `CometBFT` block building is susceptible to MEV-related issues, such as front-running and sandwich attacks, since proposers have monopolistic rights on ordering and no verification of good behavior. MEV that is created cannot be redistributed to the protocol.
-- The standard `CometBFT` block building uses a one-size-fits-all approach, which can result in inefficient transaction processing for specific applications or use cases and sub-optimal fee markets.
+- Traditional block building is susceptible to MEV-related issues, such as front-running and sandwich attacks, since proposers have monopolistic rights on ordering and no verification of good behavior. MEV that is created cannot be redistributed to the protocol.
+- Traditional block building uses a one-size-fits-all approach, which can result in inefficient transaction processing for specific applications or use cases and sub-optimal fee markets.
 - Transactions tailored for specific applications may need custom prioritization, ordering or validation rules that the mempool is otherwise unaware of because transactions within a block are currently in-differentiable when a blockchain might want them to be.
 
 ### ✅ Solution: The Block SDK
@@ -40,10 +52,28 @@ In the Block SDK, each `lane` has its own set of rules and transaction flow mana
 
 A block with separate `lanes` can be used for:
 
-1. **MEV mitigation**: a top of block lane could be designed to create an in-protocol top-of-block auction (as we are doing with the Block SDK) to recapture MEV in a transparent and governable way.
-2. **Free/reduced fee txs**: transactions with certain properties (e.g. from trusted accounts or performing encouraged actions) could leverage a free lane to reward behavior.
+1. **MEV mitigation**: a top of block lane could be designed to create an in-protocol top-of-block [auction](/docs/chains/lanes/existing-lanes/1-mev.md) to recapture MEV in a transparent and governable way.
+2. **Free/reduced fee txs**: transactions with certain properties (e.g. from trusted accounts or performing encouraged actions) could leverage a free lane to facilitate _good_ behavior.
 3. **Dedicated oracle space** Oracles could be included before other kinds of transactions to ensure that price updates occur first, and are not able to be sandwiched or manipulated.
-4. **Orderflow auctions**: an OFA lane could be constructed such that order flow providers can have their submitted transactions bundled with specific backrunners, to guarantee MEV rewards are attributed back to users. Imagine MEV-share but in protocol.
+4. **Orderflow auctions**: an OFA lane could be constructed such that order flow providers can have their submitted transactions bundled with specific backrunners, to guarantee MEV rewards are attributed back to users
 5. **Enhanced and customizable privacy**: privacy-enhancing features could be introduced, such as threshold encrypted lanes, to protect user data and maintain privacy for specific use cases.
 6. **Fee market improvements**: one or many fee markets - such as EIP-1559 - could be easily adopted for different lanes (potentially custom for certain dApps). Each smart contract/exchange could have its own fee market or auction for transaction ordering.
 7. **Congestion management**: segmentation of transactions to lanes can help mitigate network congestion by capping usage of certain applications and tailoring fee markets.
+
+### 🎆 Chains Currently Using the Block-SDK
+
+#### Mainnets
+
+| Chain Name  | Chain-ID        | Block-SDK Version |
+| ----------- | --------------- | ----------------- |
+| Juno        | `juno-1`        | `v1.0.2`          |
+| Persistence | `persistence-1` | `v1.0.2`          |
+| Initia      | `NA`            | `v1.0.2`          |
+| Prism       | `NA`            | `v1.0.2`          |
+| Terra       | `phoenix-1`     | `v1.0.2`          |
+
+#### Testnets
+
+| Chain Name | Chain-ID | Block-SDK Version |
+| ---------- | -------- | ----------------- |
+| Juno       | `uni-6`  | `v1.0.2`          |

--- a/docs/chains/lanes/1-build-your-own-lane.md
+++ b/docs/chains/lanes/1-build-your-own-lane.md
@@ -20,4 +20,466 @@ The **Base Lane** is a generic implementation of a lane. It comes out-of-the-box
 
 With it, developers can build their own lane(s) in less than 10 minutes!
 
-{{ readme }}
+# 🏗️ Build-Your-Own Lane Setup
+
+## 📦 Dependencies
+
+The Block SDK is built on top of the Cosmos SDK. The Block SDK is currently
+compatible with Cosmos SDK versions greater than or equal to `v0.47.0`.
+
+## 📥 Installation
+
+To install the Block SDK, run the following command:
+
+```bash
+$ go install github.com/skip-mev/block-sdk
+```
+
+## 🤔 How to use it [30 min]
+
+There are **five** required components to building a custom lane using the base lane:
+
+1. `Mempool` - The lane's mempool is responsible for storing transactions that
+   have been verified and are waiting to be included in proposals.
+2. `MatchHandler` - This is responsible for determining whether a transaction
+   should belong to this lane.
+3. [**OPTIONAL**] `PrepareLaneHandler` - Allows developers to define their own
+   handler to customize the how transactions are verified and ordered before they
+   are included into a proposal.
+4. [**OPTIONAL**] `CheckOrderHandler` - Allows developers to define their own
+   handler that will run any custom checks on whether transactions included in
+   block proposals are in the correct order (respecting the ordering rules of the
+   lane and the ordering rules of the other lanes).
+5. [**OPTIONAL**] `ProcessLaneHandler` - Allows developers to define their own
+   handler for processing transactions that are included in block proposals.
+6. `Configuration` - Configure high-level options for your lane.
+
+### 1. 🗄️ Mempool
+
+This is the data structure that is responsible for storing transactions as they
+are being verified and are waiting to be included in proposals.
+`block/base/mempool.go` provides an out-of-the-box implementation that should be
+used as a starting point for building out the mempool and should cover most use
+cases. To utilize the mempool, you must implement a `TxPriority[C]` struct that
+does the following:
+
+- Implements a `GetTxPriority` method that returns the priority (as defined
+  by the type `[C]`) of a given transaction.
+- Implements a `Compare` method that returns the relative priority of two
+  transactions. If the first transaction has a higher priority, the method
+  should return -1, if the second transaction has a higher priority the method
+  should return 1, otherwise the method should return 0.
+- Implements a `MinValue` method that returns the minimum priority value
+  that a transaction can have.
+
+The default implementation can be found in `block/base/mempool.go`.
+
+> Scenario
+> What if we wanted to prioritize transactions by the amount they have staked on
+> a chain?
+
+We could do the following:
+
+```golang
+// CustomTxPriority returns a TxPriority that prioritizes transactions by the
+// amount they have staked on chain. This means that transactions with a higher
+// amount staked will be prioritized over transactions with a lower amount staked.
+func (p *CustomTxPriority) CustomTxPriority() TxPriority[string] {
+    return TxPriority[string]{
+        GetTxPriority: func(ctx context.Context, tx sdk.Tx) string {
+            // Get the signer of the transaction.
+            signer := p.getTransactionSigner(tx)
+
+            // Get the total amount staked by the signer on chain.
+            // This is abstracted away in the example, but you can
+            // implement this using the staking keeper.
+            totalStake, err := p.getTotalStake(ctx, signer)
+            if err != nil {
+                return ""
+            }
+
+            return totalStake.String()
+        },
+        Compare: func(a, b string) int {
+            aCoins, _ := sdk.ParseCoinsNormalized(a)
+            bCoins, _ := sdk.ParseCoinsNormalized(b)
+
+            switch {
+            case aCoins == nil && bCoins == nil:
+                return 0
+
+            case aCoins == nil:
+                return -1
+
+            case bCoins == nil:
+                return 1
+
+            default:
+                switch {
+                case aCoins.IsAllGT(bCoins):
+                    return 1
+
+                case aCoins.IsAllLT(bCoins):
+                    return -1
+
+                default:
+                    return 0
+                }
+            }
+        },
+        MinValue: "",
+    }
+}
+```
+
+#### Using a Custom TxPriority
+
+To utilize this new priority configuration in a lane, all you have to then do
+is pass in the `TxPriority[C]` to the `NewMempool` function.
+
+```golang
+// Create the lane config
+laneCfg := NewLaneConfig(
+    ...
+    MaxTxs: 100,
+    ...
+)
+
+// Pseudocode for creating the custom tx priority
+priorityCfg := NewPriorityConfig(
+    stakingKeeper,
+    accountKeeper,
+    ...
+)
+
+
+// define your mempool that orders transactions by on-chain stake
+mempool := base.NewMempool[string](
+    priorityCfg.CustomTxPriority(), // pass in the custom tx priority
+    laneCfg.TxEncoder,
+    laneCfg.MaxTxs,
+)
+
+// Initialize your lane with the mempool
+lane := base.NewBaseLane(
+    laneCfg,
+    LaneName,
+    mempool,
+    base.DefaultMatchHandler(),
+)
+```
+
+### 2. 🤝 MatchHandler
+
+`MatchHandler` is utilized to determine if a transaction should be included in
+the lane. **This function can be a stateless or stateful check on the
+transaction!** The default implementation can be found in `block/base/handlers.go`.
+
+The match handler can be as custom as desired. Following the example above, if
+we wanted to make a lane that only accepts transactions if they have a large
+amount staked, we could do the following:
+
+```golang
+// CustomMatchHandler returns a custom implementation of the MatchHandler. It
+// matches transactions that have a large amount staked. These transactions
+// will then be charged no fees at execution time.
+//
+// NOTE: This is a stateful check on the transaction. The details of how to
+// implement this are abstracted away in the example, but you can implement
+// this using the staking keeper.
+func (h *Handler) CustomMatchHandler() base.MatchHandler {
+    return func(ctx sdk.Context, tx sdk.Tx) bool {
+        if !h.IsStakingTx(tx) {
+            return false
+        }
+
+        signer, err := getTxSigner(tx)
+        if err != nil {
+            return false
+        }
+
+        stakedAmount, err := h.GetStakedAmount(signer)
+        if err != nil {
+            return false
+        }
+
+        // The transaction can only be considered for inclusion if the amount
+        // staked is greater than some predetermined threshold.
+        return stakeAmount.GT(h.Threshold)
+    }
+}
+```
+
+#### Using a Custom MatchHandler
+
+If we wanted to create the lane using the custom match handler along with the
+custom mempool, we could do the following:
+
+```golang
+// Pseudocode for creating the custom match handler
+handler := NewHandler(
+    stakingKeeper,
+    accountKeeper,
+    ...
+)
+
+// define your mempool that orders transactions by on chain stake
+mempool := base.NewMempool[string](
+    priorityCfg.CustomTxPriority(),
+    cfg.TxEncoder,
+    cfg.MaxTxs,
+)
+
+// Initialize your lane with the mempool
+lane := base.NewBaseLane(
+    cfg,
+    LaneName,
+    mempool,
+    handler.CustomMatchHandler(),
+)
+```
+
+### [OPTIONAL] Steps 3-5
+
+The remaining steps walk through the process of creating custom block
+building/verification logic. The default implementation found in
+`block/base/handlers.go` should fit most use cases. Please reference that file
+for more details on the default implementation and whether it fits your use case.
+
+Implementing custom block building/verification logic is a bit more involved
+than the previous steps and is a all or nothing approach. This means that if
+you implement any of the handlers, you must implement all of them in most cases.
+If you do not implement all of them, the lane may have unintended behavior.
+
+### 3. 🛠️ PrepareLaneHandler
+
+The `PrepareLaneHandler` is an optional field you can set on the base lane.
+This handler is responsible for the transaction selection logic when a new proposal
+is requested.
+
+The handler should return the following for a given lane:
+
+1. The transactions to be included in the block proposal.
+2. The transactions to be removed from the lane's mempool.
+3. An error if the lane is unable to prepare a block proposal.
+
+```golang
+// PrepareLaneHandler is responsible for preparing transactions to be included
+// in the block from a given lane. Given a lane, this function should return
+// the transactions to include in the block, the transactions that must be
+// removed from the lane, and an error if one occurred.
+PrepareLaneHandler func(ctx sdk.Context,proposal BlockProposal,maxTxBytes int64)
+    (txsToInclude [][]byte, txsToRemove []sdk.Tx, err error)
+```
+
+The default implementation is simple. It will continue to select transactions
+from its mempool under the following criteria:
+
+1. The transactions is not already included in the block proposal.
+2. The transaction is valid and passes the AnteHandler check.
+3. The transaction is not too large to be included in the block.
+
+If a more involved selection process is required, you can implement your own
+`PrepareLaneHandler` and and set it after creating the base lane.
+
+```golang
+// Pseudocode for creating the custom prepare lane handler
+// This assumes that the CustomLane inherits from the base
+// lane.
+customLane := NewCustomLane(
+    cfg,
+    mempool,
+    handler.CustomMatchHandler(),
+)
+
+// Set the custom PrepareLaneHandler on the lane
+customLane.SetPrepareLaneHandler(customlane.PrepareLaneHandler())
+```
+
+### 4. ✅ CheckOrderHandler
+
+The `CheckOrderHandler` is an optional field you can set on the base lane.
+This handler is responsible for verifying the ordering of the transactions in
+the block proposal that belong to the lane.
+
+```golang
+// CheckOrderHandler is responsible for checking the order of transactions that
+// belong to a given lane. This handler should be used to verify that the
+// ordering of transactions passed into the function respect the ordering logic
+// of the lane (if any transactions from the lane are included). This function
+// should also ensure that transactions that belong to this lane are contiguous
+// and do not have any transactions from other lanes in between them.
+CheckOrderHandler func(ctx sdk.Context, txs []sdk.Tx) error
+```
+
+The default implementation is simple and utilizes the same `TxPriority` struct
+that the mempool uses to determine if transactions are in order. The criteria
+for determining if transactions are in order is as follows:
+
+1. The transactions are in order according to the `TxPriority` struct. i.e.
+   any two transactions (that match to the lane) `tx1` and `tx2` where `tx1` has a
+   higher priority than `tx2` should be ordered before `tx2`.
+2. The transactions are contiguous. i.e. there are no transactions from other
+   lanes in between the transactions that belong to this lane. i.e. if `tx1` and
+   `tx2` belong to the lane, there should be no transactions from other lanes in
+   between `tx1` and `tx2`.
+
+If a more involved ordering process is required, you can implement your own
+`CheckOrderHandler` and and set it after creating the base lane.
+
+```golang
+// Pseudocode for creating the custom check order handler
+// This assumes that the CustomLane inherits from the base
+// lane.
+customLane := NewCustomLane(
+    cfg,
+    mempool,
+    handler.CustomMatchHandler(),
+)
+
+// Set the custom CheckOrderHandler on the lane
+customLane.SetCheckOrderHandler(customlane.CheckOrderHandler())
+```
+
+### 5. 🆗 ProcessLaneHandler
+
+The `ProcessLaneHandler` is an optional field you can set on the base lane.
+This handler is responsible for verifying the transactions in the block proposal
+that belong to the lane. This handler is executed after the `CheckOrderHandler`
+so the transactions passed into this function SHOULD already be in order
+respecting the ordering rules of the lane and respecting the ordering rules of
+mempool relative to the lanes it has. This means that if the first transaction
+does not belong to the lane, the remaining transactions should not belong to
+the lane either.
+
+```golang
+// ProcessLaneHandler is responsible for processing transactions that are
+// included in a block and belong to a given lane. ProcessLaneHandler is
+// executed after CheckOrderHandler so the transactions passed into this
+// function SHOULD already be in order respecting the ordering rules of the
+// lane and respecting the ordering rules of mempool relative to the lanes it has.
+ProcessLaneHandler func(ctx sdk.Context, txs []sdk.Tx) ([]sdk.Tx, error)
+```
+
+Given the invarients above, the default implementation is simple. It will
+continue to verify transactions in the block proposal under the following criteria:
+
+1. If a transaction matches to this lane, verify it and continue. If it is not
+   valid, return an error.
+2. If a transaction does not match to this lane, return the remaining
+   transactions to the next lane to process.
+
+Similar to the setup of handlers above, if a more involved verification process
+is required, you can implement your own `ProcessLaneHandler` and and set it
+after creating the base lane.
+
+```golang
+// Pseudocode for creating the custom check order handler
+// This assumes that the CustomLane inherits from the base
+// lane.
+customLane := NewCustomLane(
+    cfg,
+    mempool,
+    handler.CustomMatchHandler(),
+)
+
+// Set the custom ProcessLaneHandler on the lane
+customLane.SetProcessLaneHandler(customlane.ProcessLaneHandler())
+```
+
+### 6. 📝 Lane Configuration
+
+Once you have created your custom lane, you can configure it in the application
+by doing the following:
+
+1. Create a custom `LaneConfig` struct that defines the configuration of the lane.
+2. Instantiate the lane with the custom `LaneConfig` struct alongside any other
+   dependencies (mempool, match handler, etc.).
+3. Instantiate a new `LanedMempool` with the custom lane.
+4. Set the `LanedMempool` on the `BaseApp` instance.
+5. Set up the proposal handlers of the Block SDK to use your lane.
+6. That's it! You're done!
+
+The lane config (`LaneConfig`) is a simple configuration object that defines
+the desired amount of block space the lane should utilize when building a
+proposal, an antehandler that is used to verify transactions as they are
+added/verified to/in a proposal, and more. By default, we recommend that user's
+pass in all of the base apps configurations (txDecoder, logger, etc.). A sample
+`LaneConfig` might look like the following:
+
+```golang
+config := base.LaneConfig{
+    Logger: app.Logger(),
+    TxDecoder: app.TxDecoder(),
+    TxEncoder: app.TxEncoder(),
+    AnteHandler: app.AnteHandler(),
+    MaxTxs: 0,
+    MaxBlockSpace: math.LegacyZeroDec(),
+    IgnoreList: []block.Lane{},
+}
+```
+
+The three most important parameters to set are the `AnteHandler`, `MaxTxs`, and `MaxBlockSpace`.
+
+#### **AnteHandler**
+
+With the default implementation, the `AnteHandler` is responsible for verifying
+transactions as they are being considered for a new proposal or are being
+processed in a proposed block. We recommend user's utilize the same antehandler
+chain that is used in the base app. If developers want a certain `AnteDecorator`
+to be ignored if it qualifies for a given lane, they can do so by using the
+`NewIgnoreDecorator` defined in `block/utils/ante.go`.
+
+For example, a free lane might want to ignore the `DeductFeeDecorator` so that
+its transactions are not charged any fees. Where ever the `AnteHandler` is
+defined, we could add the following to ignore the `DeductFeeDecorator`:
+
+```golang
+anteDecorators := []sdk.AnteDecorator{
+    ante.NewSetUpContextDecorator(),
+    ...,
+    utils.NewIgnoreDecorator(
+        ante.NewDeductFeeDecorator(
+            options.BaseOptions.AccountKeeper,
+            options.BaseOptions.BankKeeper,
+            options.BaseOptions.FeegrantKeeper,
+            options.BaseOptions.TxFeeChecker,
+        ),
+        options.FreeLane,
+    ),
+    ...,
+}
+```
+
+Anytime a transaction that qualifies for the free lane is being processed, the
+`DeductFeeDecorator` will be ignored and no fees will be deducted!
+
+#### **MaxTxs**
+
+This sets the maximum number of transactions allowed in the mempool with the semantics:
+
+- if `MaxTxs` == 0, there is no cap on the number of transactions in the mempool
+- if `MaxTxs` > 0, the mempool will cap the number of transactions it stores,
+  and will prioritize transactions by their priority and sender-nonce
+  (sequence number) when evicting transactions.
+- if `MaxTxs` < 0, `Insert` is a no-op.
+
+#### **MaxBlockSpace**
+
+MaxBlockSpace is the maximum amount of block space that the lane will attempt
+to fill when building a proposal. This parameter may be useful lanes that
+should be limited (such as a free or onboarding lane) in space usage.
+Setting this to 0 will allow the lane to fill the block with as many
+transactions as possible.
+
+If a block proposal request has a `MaxTxBytes` of 1000 and the lane has a
+`MaxBlockSpace` of 0.5, the lane will attempt to fill the block with 500 bytes.
+
+#### **[OPTIONAL] IgnoreList**
+
+`IgnoreList` defines the list of lanes to ignore when processing transactions.
+For example, say there are two lanes: default and free. The free lane is
+processed after the default lane. In this case, the free lane should be added
+to the ignore list of the default lane. Otherwise, the transactions that belong
+to the free lane will be processed by the default lane (which accepts all
+transactions by default).

--- a/docs/chains/lanes/existing-lanes/1-mev.md
+++ b/docs/chains/lanes/existing-lanes/1-mev.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 :::info TLDR
 
-The `MEV Lane` allows top-of-block MEV auctions in-protocol, revenue being redistributed to chains.
+The `MEV Lane` allows top-of-block MEV auctions in-protocol, with revenue being redistributed to chains.
 
 If you have not already, we recommend following the [General Setup](/docs/chains/0-integrate-the-sdk.md) guide first!
 
@@ -16,11 +16,14 @@ Please [**reach out to us**](https://skip.money/contact) if you need help!
 
 ### 💰 Overview
 
-Blockspace is valuable, and MEV bots find arbitrage opportunities to capture value. The `MEV Lane` provides a fair auction for these by leveraging the `x/builder` module inside the Block SDK. The `MEV Lane` ensures protocols are recapturing their value while ensuring users are not front-run or sandwiched in the process.
+Blockspace is valuable, and MEV bots find arbitrage opportunities to capture value. The `MEV Lane` provides a fair auction for these by leveraging the `x/auction` module. The `MEVLane` ensures that proposals are constructed in accordance with the `x/auction`'s view of all bids, and the `x/auction` is responsible for ordering bids + keeping track of bids + selecting auction winners.
 
-The Block SDK uses the app-side `LanedMempool`, `PrepareLane` / `ProcessLane`, and `CheckTx` to create an MEV marketplace inside the protocol. It introduces a new message type, called a `MsgAuctionBid`, that allows the submitter to execute multiple transactions at the **top of the block atomically** (atomically = directly next to each other).
+The Block SDK uses the app-side `LanedMempool`, `PrepareLane` / `ProcessLane`, and `CheckTx` to create an MEV marketplace inside the protocol. It introduces a new message type, called a `MsgAuctionBid`, that allows the submitter to execute multiple transactions at the **top of the block atomically** atomically.
+:::note
+**atomicity** here refers to **transaction inclusion** and not **transaction execution**. The `x/auction` module does not make any guarantees for atomic execution, some transactions in a bundle may fail!!
+:::
 
-This means that ‘searchers’ can find opportunities in the mempool, backrun them, and submit them at the top of the block. This covers most MEV recapture via arbitrage and liquidations. It can be configured to **not allow** for sandwich attacks or harmful MEV.
+This means that ‘searchers’ can find opportunities in the mempool, backrun them, and submit them at the top of the block. This covers most MEV recapture via arbitrage, liquidations, backrunning, oracle-updates, etc. It can be configured to **not allow** for sandwich attacks or harmful MEV.
 
 ### 📖 Set Up [10 mins]
 
@@ -30,6 +33,274 @@ This means that ‘searchers’ can find opportunities in the mempool, backrun t
 2. Import and configure the `MEV Lane` (alongside any other desired lanes) into their base app.
 3. Import and configure the Block SDK mempool into their base app.
 4. Import and configure the Block SDK `Prepare` / `Process` proposal handlers into their base app.
-5. Import and instantiate the `x/builder` module into their base app.
+5. Import and instantiate the `x/auction` module into their base app.
 
-{{ readme }}
+# 🏗️ MEV Lane Setup
+
+## 📦 Dependencies
+
+The Block SDK is built on top of the Cosmos SDK. The Block SDK is currently
+compatible with Cosmos SDK versions greater than or equal to `v0.47.0`.
+
+The `MEVLane` requires that apps use the `LanedMempool` as their app-side mempool, see [here](/docs/chains/0-integrate-the-sdk.md)
+
+### Release Compatibility Matrix
+
+| Block SDK Version | Cosmos SDK |
+| :---------------: | :--------: |
+|     `v1.x.x`      | `v0.47.x`  |
+|     `v2.x.x`      | `v0.50.x`  |
+
+## 📥 Installation
+
+To install the Block SDK, run the following command:
+
+```bash
+$ go install github.com/skip-mev/block-sdk
+```
+
+## 📚 Usage
+
+1. This guide assumes you have already set up the [Block SDK (and the default lane)](https://docs.skip.money/chains/overview)
+2. You will need to instantiate the `x/auction` module into your application. This
+   module is responsible for processing auction transactions and distributing revenue
+   to the auction house. The `x/auction` module is also responsible for ensuring the
+   validity of auction transactions, and maintaining the set of bids / revenue distribution.
+   The `MEVLane` is responsible for constructing blocks with transactions from the winning bid.
+3. Next, add the MEV lane into the `lane` object on your `app.go`. The first
+   lane is the highest priority lane and the last lane is the lowest priority lane.
+   Since the MEV lane is meant to auction off the top of the block, **it should be
+   the highest priority lane**. The default lane should follow.
+4. You will also need to create a `PrepareProposalHandler` and a
+   `ProcessProposalHandler` that will be responsible for preparing and processing
+   proposals respectively. Configure the order of the lanes in the
+   `PrepareProposalHandler` and `ProcessProposalHandler` to match the order of the
+   lanes in the `LanedMempool`.
+
+NOTE: This example walks through setting up the MEV and Default lanes.
+
+1. Import the necessary dependencies into your application. This includes the
+   Block SDK proposal handlers + mempool, keeper, auction types, and auction
+   module. This tutorial will go into more detail into each of the dependencies.
+
+   ```go
+   import (
+    ...
+    "github.com/skip-mev/block-sdk/abci"
+    "github.com/skip-mev/block-sdk/lanes/mev"
+    "github.com/skip-mev/block-sdk/lanes/base"
+    auctionmodule "github.com/skip-mev/block-sdk/x/auction"
+    auctionkeeper "github.com/skip-mev/block-sdk/x/auction/keeper"
+    auctiontypes "github.com/skip-mev/block-sdk/x/auction/types"
+    auctionante "github.com/skip-mev/block-sdk/x/auction/ante"
+     ...
+   )
+   ```
+
+2. Add the `x/auction` module to the the `AppModuleBasic` manager. This manager is in
+   charge of setting up basic, non-dependent module elements such as codec
+   registration and genesis verification. This will register the special
+   `MsgAuctionBid` message. When users want to bid for top of block execution,
+   they will submit a transaction - which we call an auction transaction - that
+   includes a single `MsgAuctionBid`. We prevent any other messages from being
+   included in auction transaction to prevent malicious behavior - such as front
+   running or sandwiching.
+
+   ```go
+   var (
+     ModuleBasics = module.NewBasicManager(
+       ...
+       auctionmodule.AppModuleBasic{},
+     )
+     ...
+   )
+   ```
+
+3. The auction `Keeper` is MEV lane's gateway to processing special `MsgAuctionBid`
+   messages that allow users to participate in the top of block auction, distribute
+   revenue to the auction house, and ensure the validity of auction transactions.
+
+   a. First add the keeper to the app's struct definition. We also want to add
+   MEV lane's custom checkTx handler to the app's struct definition. This will
+   allow us to override the default checkTx handler to process bid transactions
+   before they are inserted into the `LanedMempool`. NOTE: The custom handler
+   is required as otherwise the auction can be held hostage by a malicious
+   users.
+
+   ```go
+   type App struct {
+   ...
+   // auctionKeeper is the keeper that handles processing auction transactions
+   AuctionKeeper         auctionkeeper.Keeper
+
+   // Custom checkTx handler
+   checkTxHandler mev.CheckTx
+   }
+   ```
+
+   b. Add the auction module to the list of module account permissions. This will
+   instantiate the auction module account on genesis.
+
+   ```go
+   maccPerms = map[string][]string{
+   auction.ModuleName: nil,
+   ...
+   }
+   ```
+
+   c. Instantiate the Block SDK's `LanedMempool` with the application's
+   desired lanes.
+
+   ```go
+   // 1. Create the lanes.
+   //
+   // NOTE: The lanes are ordered by priority. The first lane is the
+   // highest priority
+   // lane and the last lane is the lowest priority lane. Top of block
+   // lane allows transactions to bid for inclusion at the top of the next block.
+   //
+   // For more information on how to utilize the LaneConfig please
+   // visit the README in docs.skip.money/chains/lanes/build-your-own-lane#-lane-config.
+   //
+   // MEV lane hosts an auction at the top of the block.
+   mevConfig := base.LaneConfig{
+       Logger:        app.Logger(),
+       TxEncoder:     app.txConfig.TxEncoder(),
+       TxDecoder:     app.txConfig.TxDecoder(),
+       MaxBlockSpace: math.LegacyZeroDec(),
+       MaxTxs:        0,
+   }
+   mevLane := mev.NewMEVLane(
+       mevConfig,
+       mev.NewDefaultAuctionFactory(app.txConfig.TxDecoder()),
+   )
+
+   // default lane accepts all other transactions.
+   defaultConfig := base.LaneConfig{
+       Logger:        app.Logger(),
+       TxEncoder:     app.txConfig.TxEncoder(),
+       TxDecoder:     app.txConfig.TxDecoder(),
+       MaxBlockSpace: math.LegacyZeroDec(),
+       MaxTxs:        0,
+   }
+   defaultLane := base.NewStandardLane(defaultConfig)
+
+   // 2. Set up the relative priority of lanes
+   lanes := []block.Lane{
+       mevLane,
+       defaultLane,
+   }
+   mempool := block.NewLanedMempool(app.Logger(), true, lanes...)
+   app.App.SetMempool(mempool)
+   ```
+
+   d. Add the `x/auction` module's `AuctionDecorator` to the ante-handler
+   chain. The `AuctionDecorator` is an AnteHandler decorator that enforces
+   various chain configurable MEV rules.
+
+   ```go
+   anteDecorators := []sdk.AnteDecorator{
+       ante.NewSetUpContextDecorator(),
+       ...
+       auctionante.NewauctionDecorator(
+       options.auctionKeeper,
+       options.TxEncoder,
+       options.TOBLane,
+       options.Mempool,
+       ),
+   }
+
+   anteHandler := sdk.ChainAnteDecorators(anteDecorators...)
+   app.SetAnteHandler(anteHandler)
+
+   // Set the antehandlers on the lanes.
+   //
+   // NOTE: This step is required as otherwise the lanes will not be able to
+   // process auction transactions.
+   for _, lane := range lanes {
+       lane.SetAnteHandler(anteHandler)
+   }
+   app.App.SetAnteHandler(anteHandler)
+   ```
+
+   e. Instantiate the auction keeper, store keys, and module manager. Note, be
+   sure to do this after all the required keeper dependencies have been instantiated.
+
+   ```go
+   keys := storetypes.NewKVStoreKeys(
+       auctiontypes.StoreKey,
+       ...
+   )
+
+   ...
+   app.auctionKeeper := auctionkeeper.NewKeeper(
+       appCodec,
+       keys[auctiontypes.StoreKey],
+       app.AccountKeeper,
+       app.BankKeeper,
+       app.DistrKeeper,
+       app.StakingKeeper,
+       authtypes.NewModuleAddress(govv1.ModuleName).String(),
+   )
+
+
+   app.ModuleManager = module.NewManager(
+       auction.NewAppModule(appCodec, app.auctionKeeper),
+       ...
+   )
+   ```
+
+   f. Configure the proposal/checkTx handlers on base app.
+
+   ```go
+   // Create the proposal handler that will be used to build and validate blocks.
+   proposalHandler := abci.NewProposalHandler(
+       app.Logger(),
+       app.txConfig.TxDecoder(),
+       mempool,
+   )
+   app.App.SetPrepareProposal(proposalHandler.PrepareProposalHandler())
+   app.App.SetProcessProposal(proposalHandler.ProcessProposalHandler())
+
+   // Set the custom CheckTx handler on BaseApp.
+   checkTxHandler := mev.NewCheckTxHandler(
+       app.App,
+       app.txConfig.TxDecoder(),
+       mevLane,
+       anteHandler,
+   )
+   app.SetCheckTx(checkTxHandler.CheckTx())
+
+   // CheckTx will check the transaction with the provided checkTxHandler.
+   // We override the default handler so that we can verify transactions
+   // before they are inserted into the mempool. With the CheckTx, we can
+   // verify the bid transaction and all of the bundled transactions
+   // before inserting the bid transaction into the mempool.
+   func (app *TestApp) CheckTx(req *cometabci.RequestCheckTx)
+       (*cometabci.ResponseCheckTx, error) {
+       return app.checkTxHandler(req)
+   }
+
+   // SetCheckTx sets the checkTxHandler for the app.
+   func (app *TestApp) SetCheckTx(handler mev.CheckTx) {
+       app.checkTxHandler = handler
+   }
+   ```
+
+   g. Finally, update the app's `InitGenesis` order.
+
+   ```go
+   genesisModuleOrder := []string{
+       auctiontypes.ModuleName,
+       ...,
+   }
+   ```
+
+## Params
+
+- **MaxBundleSize** - What is the maximal number of transactions a bundle can have?
+- **EscrowAccountAddress** - Where does the chain collect bid revenue? Notice, this is an `sdk.AccAdress` and is configured on genesis, or via `ParamChange` proposals.
+- **ReserveFee** - The minimum possible bid. Notice, no bids less than the `ReserveFee` will be accepted.
+- **MinBidIncrement** - This is the minimum difference from the max bid that `x/auction` module will accept. I.e if the current max bid is `12ujuno`, and `MinBidIncrement = 1`, then all new bids must be greater than `13ujuno` to be considered.
+- **FrontRunningProtection** - This determines whether front-running bundles will be accepted by the `x/auction` module
+- **ProposerFee** - This is a fractional value, i.e `0 <= ProposerFee <= 1`, this determines how much of the winning bid from the previous block goes to the proposer of that block, the rest will be sent to the `EscrowAccountAddress`

--- a/docs/chains/lanes/existing-lanes/2-free.md
+++ b/docs/chains/lanes/existing-lanes/2-free.md
@@ -31,4 +31,139 @@ The free lane implements the same `ABCI++` interface as the other lanes, and doe
 3. Import and configure the Block SDK mempool into their base app.
 4. Import and configure the Block SDK `Prepare` / `Process` proposal handlers into their base app.
 
-{{ readme }}
+# 🏗️ Free Lane Setup
+
+## 📦 Dependencies
+
+The Block SDK is built on top of the Cosmos SDK. The Block SDK is currently
+compatible with Cosmos SDK versions greater than or equal to `v0.47.0`.
+
+### Release Compatibility Matrix
+
+| Block SDK Version | Cosmos SDK |
+| :---------------: | :--------: |
+|     `v1.x.x`      | `v0.47.x`  |
+|     `v2.x.x`      | `v0.50.x`  |
+
+## 📥 Installation
+
+To install the Block SDK, run the following command:
+
+```bash
+$ go install github.com/skip-mev/block-sdk
+```
+
+## 📚 Usage
+
+1. First determine the set of lanes that you want to use in your application. The
+   available lanes can be found in our
+   [Lane App Store](https://docs.skip.money/chains/lanes/existing-lanes/default).
+   In your base application, you will need to create a `LanedMempool` composed of the
+   lanes you want to use. _The free lane should not exist on its own. At minimum, it
+   is recommended that the free lane is paired with the default lane._
+2. Next, order the lanes by priority. The first lane is the highest priority lane
+   and the last lane is the lowest priority lane.
+3. Set up your `FeeDeductorDecorator` to ignore the free lane where ever you
+   initialize your `AnteHandler`. This will ensure that the free lane is not
+   subject to deducting transaction fees.
+4. You will also need to create a `PrepareProposalHandler` and a
+   `ProcessProposalHandler` that will be responsible for preparing and processing
+   proposals respectively. Configure the order of the lanes in the
+   `PrepareProposalHandler` and `ProcessProposalHandler` to match the order of the
+   lanes in the `LanedMempool`.
+
+NOTE: This example walks through setting up the Free and Default lanes.
+
+```golang
+import (
+    "github.com/skip-mev/block-sdk/abci"
+    "github.com/skip-mev/block-sdk/block/base"
+    defaultlane "github.com/skip-mev/block-sdk/lanes/base"
+    freelane "github.com/skip-mev/block-sdk/lanes/free"
+)
+
+...
+
+func NewApp() {
+    ...
+    // 1. Create the lanes.
+    //
+    // NOTE: The lanes are ordered by priority. The first lane is the highest priority
+    // lane and the last lane is the lowest priority lane. Top of block lane allows
+    // transactions to bid for inclusion at the top of the next block.
+    //
+    // For more information on how to utilize the LaneConfig please
+    // visit the README in docs.skip.money/chains/lanes/build-your-own-lane#-lane-config.
+    //
+    // Set up the configuration of the free lane and instantiate it.
+    freeConfig := base.LaneConfig{
+        Logger:        app.Logger(),
+        TxEncoder:     app.txConfig.TxEncoder(),
+        TxDecoder:     app.txConfig.TxDecoder(),
+        MaxBlockSpace: math.LegacyZeroDec(),
+        MaxTxs:        0,
+    }
+    freeLane := freelane.NewFreeLane(freeConfig, base.DefaultTxPriority(), freelane.DefaultMatchHandler())
+
+    // Default lane accepts all transactions.
+    defaultConfig := base.LaneConfig{
+        Logger:        app.Logger(),
+        TxEncoder:     app.txConfig.TxEncoder(),
+        TxDecoder:     app.txConfig.TxDecoder(),
+        MaxBlockSpace: math.LegacyZeroDec(),
+        MaxTxs:        0,
+    }
+    defaultLane := defaultlane.NewDefaultLane(defaultConfig)
+
+    // 2. Set up the relative priority of lanes
+    lanes := []block.Lane{
+        freeLane,
+        defaultLane,
+    }
+    mempool := block.NewLanedMempool(app.Logger(), true, lanes...)
+    app.App.SetMempool(mempool)
+
+    ...
+
+    // 3. Set up the ante handler.
+    //
+    // This will allow any transaction that matches the to the free lane to
+    // be processed without paying any fees.
+    anteDecorators := []sdk.AnteDecorator{
+		ante.NewSetUpContextDecorator(),
+        ...
+		utils.NewIgnoreDecorator(
+			ante.NewDeductFeeDecorator(
+				options.BaseOptions.AccountKeeper,
+				options.BaseOptions.BankKeeper,
+				options.BaseOptions.FeegrantKeeper,
+				options.BaseOptions.TxFeeChecker,
+			),
+			options.FreeLane,
+		),
+        ...
+	}
+
+    anteHandler := sdk.ChainAnteDecorators(anteDecorators...)
+
+    // Set the lane ante handlers on the lanes.
+    //
+    // NOTE: This step is very important. Without the antehandlers, lanes will not
+    // be able to verify transactions.
+    for _, lane := range lanes {
+        lane.SetAnteHandler(anteHandler)
+    }
+    app.App.SetAnteHandler(anteHandler)
+
+    // 4. Set the abci handlers on base app
+    proposalHandler := abci.NewProposalHandler(
+        app.Logger(),
+        app.TxConfig().TxDecoder(),
+        mempool,
+    )
+    app.App.SetPrepareProposal(proposalHandler.PrepareProposalHandler())
+    app.App.SetProcessProposal(proposalHandler.ProcessProposalHandler())
+
+    ...
+}
+```

--- a/docs/select/0-intro.md
+++ b/docs/select/0-intro.md
@@ -20,7 +20,7 @@ Check out [Quickstart](/docs/select/0-intro.md) to set up Skip Select now. It ta
 
 Validators that integrate with Skip Select:
 
-- Allow MEV to be captured in their blocks without needing to sign headers for unseen blocks, **increasing block rewards** without sacrificing their builder rights
+- Allow MEV to be captured in their blocks without needing to sign headers for unseen blocks, **increasing block rewards** without sacrificing their auction rights
 - **Can prevent toxic MEV strategies** like frontrunning & sandwich attacks, while still capturing revenue from other forms of MEV
 - Can configure **how much MEV revenue to keep** and how much to share with delegates and the network
 - **Do not need to modify** their consensus key signing services (e.g. Horcrux, TMKMS, or custom), or make any new security assumptions


### PR DESCRIPTION
## In This PR
- I rename all references to `builder` -> `auction`
- I also address the feedback from [here](https://www.notion.so/skip-protocol/Barry-Notes-on-Docs-95e4b308261f485fb48100d26b424a9b), in particular...
1. I update the overview page to include a list of integrated chains + an example highway analogy
2. Add an `Architecture` section to [0-integrate-the-sdk.md](https://github.com/skip-mev/docs/compare/nv/auction-module-fixes?expand=1#diff-53f55fbf141ed070c7d04b08dc0704b760810f65c324d4662e15fd4925910a78) before the `Set Up` header
   - In this section I explain, `Prepare / ProcessProposal`, `AppSide Mempools`, and how the `LaneMempool` is an implementation of an app-side mempool, composed of lanes.
3. 